### PR TITLE
Pass extra render_template_for arguments to render

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GIT
 PATH
   remote: .
   specs:
-    shift_commerce-rails (0.2.0)
+    shift_commerce-rails (0.3.0)
       activemerchant (~> 1.54)
 
 GEM

--- a/app/helpers/shift_commerce/rails/template_definition_helper.rb
+++ b/app/helpers/shift_commerce/rails/template_definition_helper.rb
@@ -1,10 +1,12 @@
 module ShiftCommerce
   module Rails
     module TemplateDefinitionHelper
-      def render_template_for(item)
+      def render_template_for(item, *args)
         tpl = item.template_definition
         if(tpl.present?)
-          render "template_definitions/#{tpl.reference}"
+          render "template_definitions/#{tpl.reference}", *args
+        else
+          render *args
         end
       end
     end

--- a/lib/shift_commerce/rails/version.rb
+++ b/lib/shift_commerce/rails/version.rb
@@ -1,5 +1,5 @@
 module ShiftCommerce
   module Rails
-    VERSION = "0.2.1"
+    VERSION = "0.3.0"
   end
 end


### PR DESCRIPTION
This PR allows the user to pass extra arguments to `render_template_for`, which allows us to render a Shift template with all the power of Rails' `render`. We use it in Matalan to pass `layout: false`.