### PR TITLE
Feature/custom slugs

### DIFF
--- a/app/helpers/shift_commerce/rails/menu_items_helper.rb
+++ b/app/helpers/shift_commerce/rails/menu_items_helper.rb
@@ -11,15 +11,7 @@ module ShiftCommerce
       end
 
       def url_for_menu_item(menu_item)
-        item = menu_item.item
-        case item.class.to_s
-          when "FlexCommerce::Product" then "/products/#{item.slug}"
-          when "FlexCommerce::StaticPage" then pages_path slug: item.slug
-          when "FlexCommerce::Category" then "/categories/web/#{item.slug}"
-          else raise "Item #{item.class} is not defined in menu_items helper - so unable to calculate url"
-        end
-
-
+        return "/#{menu_item.item.slug}"
       end
     end
   end

--- a/lib/shift_commerce/rails/version.rb
+++ b/lib/shift_commerce/rails/version.rb
@@ -1,5 +1,5 @@
 module ShiftCommerce
   module Rails
-    VERSION = "0.3.0"
+    VERSION = "0.3.1"
   end
 end


### PR DESCRIPTION
Removes logic from `#url_for_menu_item` as it is no longer needed with custom slugs.