### PR TITLE
Update menus helper

### DIFF
--- a/app/helpers/shift_commerce/rails/menu_items_helper.rb
+++ b/app/helpers/shift_commerce/rails/menu_items_helper.rb
@@ -11,7 +11,7 @@ module ShiftCommerce
       end
 
       def url_for_menu_item(menu_item)
-        return "/#{menu_item.item.slug}"
+        return "/#{menu_item.path}"
       end
     end
   end


### PR DESCRIPTION
Changes the `url_for_menu_item` to use the path that is returned as part of the menu item instead of requiring the whole related displayable et al.