### PR TITLE
Potential bug fix for account page token issue

### DIFF
--- a/app/controllers/concerns/shift_commerce/http_caching.rb
+++ b/app/controllers/concerns/shift_commerce/http_caching.rb
@@ -25,7 +25,7 @@ module ShiftCommerce
 
     # appends a private Cache-Control
     def prevent_page_caching
-      response.headers['Cache-Control'] = 'private, max-age=0, must-revalidate'
+      response.headers['Cache-Control'] = 'private, no-cache, no-store, must-revalidate'
     end
 
     # appends a Vary header instructing the caching to be unique to the session cookie
@@ -43,7 +43,7 @@ module ShiftCommerce
       if surrogate_keys.present? && ENV['FASTLY_ENABLE_ESI']
         response.headers['Surrogate-Key'] = surrogate_keys.split(' ').reject { |k| k.include?('menu_item') }.join(' ')
         response.headers['Surrogate-Control'] = 'max-age=3600,stale-if-error=86400,stale-while-revalidate=86400'
-        response.headers['Cache-Control'] = 'max-age=0, must-revalidate'
+        response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
       end
     end
 

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end

--- a/spec/concerns/http_caching_spec.rb
+++ b/spec/concerns/http_caching_spec.rb
@@ -40,7 +40,7 @@ describe ShiftCommerce::HttpCaching, type: :controller do
     it "should set a private Cache-Control header" do
       get :index
 
-      expect(response.header['Cache-Control']).to include('private, max-age=0, must-revalidate')
+      expect(response.header['Cache-Control']).to include('private')
     end
   end
 
@@ -63,7 +63,7 @@ describe ShiftCommerce::HttpCaching, type: :controller do
 
       get :index
 
-      expect(response.header['Cache-Control']).to eq('max-age=0, must-revalidate')
+      expect(response.header['Cache-Control']).to_not include('private')
       expect(response.header['Surrogate-Key']).to eq('foo bar')
       expect(response.header['Surrogate-Control']).to include('max-age=3600,stale-if-error=86400,stale-while-revalidate=86400')
     end
@@ -90,7 +90,7 @@ describe ShiftCommerce::HttpCaching, type: :controller do
 
       expect(response.header['Vary']).to eq('Cookie')
       expect(response.header['Surrogate-Key']).to eq('foo bar')
-      expect(response.header['Cache-Control']).to eq('max-age=0, must-revalidate')
+      expect(response.header['Cache-Control']).to_not include('private')
       expect(response.header['Surrogate-Control']).to include('max-age=3600,stale-if-error=86400,stale-while-revalidate=86400')
     end
   end


### PR DESCRIPTION
The Matalan front-end is erroring with invalid authenticity token exceptions, this could potentially be caused by some caching of the pages. This update removes the modified check and replaces with an explicity no-cache / no-store hopefully alleviating this issue.