### PR TITLE
Extract Preview Concern

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    shiftcommerce-rails (0.4.0)
+    shiftcommerce-rails (0.4.2)
       activemerchant (~> 1.54)
       rails (~> 4.2.7)
 
@@ -42,7 +42,7 @@ GEM
     activejob (4.2.7.1)
       activesupport (= 4.2.7.1)
       globalid (>= 0.3.0)
-    activemerchant (1.60.0)
+    activemerchant (1.61.0)
       activesupport (>= 3.2.14, < 5.1)
       builder (>= 2.1.2, < 4.0.0)
       i18n (>= 0.6.9)
@@ -185,4 +185,4 @@ DEPENDENCIES
   webmock (~> 1.24.2)
 
 BUNDLED WITH
-   1.13.5
+   1.13.6

--- a/app/controllers/concerns/shift_commerce/preview_state_management.rb
+++ b/app/controllers/concerns/shift_commerce/preview_state_management.rb
@@ -1,0 +1,31 @@
+#
+# PreviewStateManagement concern
+#
+# This module contains logic for handling the preview state
+#
+module PreviewStateManagement
+  extend ActiveSupport::Concern
+
+  included do
+    # Check for the previewed state.
+    around_action :handle_preview_state
+  end
+
+  protected
+
+  def handle_preview_state
+    if params[:preview].present?
+      begin
+        # Doing this is not particular pretty and raises a question to thread
+        # safety of the underlying gem implementation. This MUST be addressed
+        # later - FIXME
+        FlexCommerceApi::ApiBase.reconfigure_all include_previewed: true
+        yield
+      ensure
+        FlexCommerceApi::ApiBase.reconfigure_all
+      end
+    else
+      yield
+    end
+  end
+end

--- a/app/controllers/concerns/shift_commerce/preview_state_management.rb
+++ b/app/controllers/concerns/shift_commerce/preview_state_management.rb
@@ -3,29 +3,31 @@
 #
 # This module contains logic for handling the preview state
 #
-module PreviewStateManagement
-  extend ActiveSupport::Concern
+module ShiftCommerce
+  module PreviewStateManagement
+    extend ActiveSupport::Concern
 
-  included do
-    # Check for the previewed state.
-    around_action :handle_preview_state
-  end
+    included do
+      # Check for the previewed state.
+      around_action :handle_preview_state
+    end
 
-  protected
+    protected
 
-  def handle_preview_state
-    if params[:preview].present?
-      begin
-        # Doing this is not particular pretty and raises a question to thread
-        # safety of the underlying gem implementation. This MUST be addressed
-        # later - FIXME
-        FlexCommerceApi::ApiBase.reconfigure_all include_previewed: true
+    def handle_preview_state
+      if params[:preview].present?
+        begin
+          # Doing this is not particular pretty and raises a question to thread
+          # safety of the underlying gem implementation. This MUST be addressed
+          # later - FIXME
+          FlexCommerceApi::ApiBase.reconfigure_all include_previewed: true
+          yield
+        ensure
+          FlexCommerceApi::ApiBase.reconfigure_all
+        end
+      else
         yield
-      ensure
-        FlexCommerceApi::ApiBase.reconfigure_all
       end
-    else
-      yield
     end
   end
 end

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.4.2'
+  VERSION = '0.4.3'
 end

--- a/spec/concerns/preview_state_management_spec.rb
+++ b/spec/concerns/preview_state_management_spec.rb
@@ -48,7 +48,7 @@ describe ShiftCommerce::PreviewStateManagement, type: :controller do
     stub_request(:get, /.*\/testaccount\/v1\/static_pages\/1\.json_api/).
       to_return(status: 200, body: STANDARD_RESPONSE, headers: { 'Content-Type': 'application/vnd.api+json' })
     stub_request(:get, /.*\/testaccount\/v1\/static_pages\/1\.json_api\?preview=true/).
-      to_return(status: 200, body: PREVIEW_RESPONSE)
+      to_return(status: 200, body: PREVIEW_RESPONSE, headers: { 'Content-Type': 'application/vnd.api+json' })
 
     @controller = PreviewStateManagementController.new
 
@@ -67,9 +67,9 @@ describe ShiftCommerce::PreviewStateManagement, type: :controller do
 
   context 'with the preview enabled' do
     it "should return the scheduled content" do
-      get :index
+      get :index, preview: true
 
-      false
+      expect(response.body).to include('Preview')
     end
   end
 

--- a/spec/concerns/preview_state_management_spec.rb
+++ b/spec/concerns/preview_state_management_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+class PreviewStateManagementController < ApplicationController
+  include ShiftCommerce::PreviewStateManagement
+
+  def index
+    page = FlexCommerce::StaticPage.includes([]).find(1).first
+    render html: page.body_content
+  end
+end
+
+describe ShiftCommerce::PreviewStateManagement, type: :controller do
+  STANDARD_RESPONSE = {
+    data: {
+      id: "1",
+      type: "static_pages",
+      links: {
+        self: "/testaccount/v1/static_pages/1.json_api"
+      },
+      attributes: {
+        body_content: "Published",
+        published: true
+      }
+    },
+    links: {
+      self: "/testaccount/v1/static_pages/1.json_api"
+    }
+  }.to_json
+
+  PREVIEW_RESPONSE = {
+    data: {
+      id: "1",
+      type: "static_pages",
+      links: {
+        self: "/testaccount/v1/static_pages/1.json_api"
+      },
+      attributes: {
+        body_content: "Preview",
+        published: true
+      }
+    },
+    links: {
+      self: "/testaccount/v1/static_pages/1.json_api?preview=true"
+    }
+  }.to_json
+
+  before do
+    stub_request(:get, /.*\/testaccount\/v1\/static_pages\/1\.json_api/).
+      to_return(status: 200, body: STANDARD_RESPONSE, headers: { 'Content-Type': 'application/vnd.api+json' })
+    stub_request(:get, /.*\/testaccount\/v1\/static_pages\/1\.json_api\?preview=true/).
+      to_return(status: 200, body: PREVIEW_RESPONSE)
+
+    @controller = PreviewStateManagementController.new
+
+    Rails.application.routes.draw do
+      get '/' => 'preview_state_management#index'
+    end
+  end
+
+  context 'with the preview disabled' do
+    it "should return the published content" do
+      get :index
+
+      expect(response.body).to include('Published')
+    end
+  end
+
+  context 'with the preview enabled' do
+    it "should return the scheduled content" do
+      get :index
+
+      false
+    end
+  end
+
+end


### PR DESCRIPTION
This PR extracts the PreviewStateManagement concern from the Matalan codebase, and includes it in this gem. It also implements two tests to ensure the concern is working correctly.