### PR TITLE
Extract NotFoundRedirects and ResourceUrl concerns

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Declare your gem's dependencies in shiftcommerce.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and
 # development dependencies will be added by default to the :development group.
-gem "flex_commerce_api", git: "https://github.com/flex-commerce/flex-ruby-gem.git", tag: 'v0.6.13'
+gem "flex_commerce_api", git: "https://github.com/flex-commerce/flex-ruby-gem.git", tag: 'v0.6.20.2'
 gemspec
 
 # Declare any dependencies that are still in development here instead of in

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/flex-commerce/flex-ruby-gem.git
-  revision: 32c1f055ed2bed7b816c0aed692f54cf4decc256
-  tag: v0.6.13
+  revision: ffa8ba447c28fa8caaf517fd165bf5740e025e97
+  tag: v0.6.20.2
   specs:
-    flex_commerce_api (0.6.13)
+    flex_commerce_api (0.6.20)
       activesupport (>= 4.0)
       faraday-http-cache (= 1.3.0)
       json_api_client (= 1.1.1)
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    shiftcommerce-rails (0.4.2)
+    shiftcommerce-rails (0.4.6)
       activemerchant (~> 1.54)
       rails (~> 4.2.7)
 
@@ -70,12 +70,12 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    faraday (0.9.2)
+    faraday (0.10.0)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.0)
       faraday (~> 0.8)
-    faraday_middleware (0.10.0)
-      faraday (>= 0.7.4, < 0.10)
+    faraday_middleware (0.10.1)
+      faraday (>= 0.7.4, < 1.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hashdiff (0.3.0)
@@ -100,7 +100,7 @@ GEM
     multipart-post (2.0.0)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-    oj (2.17.4)
+    oj (2.18.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)

--- a/app/controllers/concerns/shift_commerce/not_found_redirects.rb
+++ b/app/controllers/concerns/shift_commerce/not_found_redirects.rb
@@ -8,8 +8,7 @@ module ShiftCommerce
     extend ActiveSupport::Concern
 
     included do
-      rescue_from ::FlexCommerceApi::Error::NotFound, ActionController::RoutingError,
-        with: :handle_resource_not_found
+      rescue_from FlexCommerceApi::Error::NotFound, FlexCommerceApi::Error::InternalServer, with: :handle_resource_not_found
     end
 
     # default handler for API lookup 404 Not Found responses
@@ -28,12 +27,16 @@ module ShiftCommerce
     # when redirects cannot be found, handle using regular 404 process
     rescue ::FlexCommerceApi::Error::NotFound => ex
       log_exception(ex)
-      handle_not_found(exception)
+      handle_not_found(ex)
     end
 
     # default behavior for handling not found errors, easily overridable and reusable
     def handle_not_found(exception = nil)
-      raise(exception)
+      if exception
+        raise(exception)
+      else
+        raise StandardError, "#{self.class.name}#handle_not_found called without exception, this method should be overridden."
+      end
     end
 
     protected

--- a/app/controllers/concerns/shift_commerce/not_found_redirects.rb
+++ b/app/controllers/concerns/shift_commerce/not_found_redirects.rb
@@ -1,0 +1,68 @@
+#
+# NotFoundRedirects
+#
+# When a 404 is hit, we lookup possible redirects
+#
+module ShiftCommerce
+  module NotFoundRedirects
+    extend ActiveSupport::Concern
+
+    included do
+      rescue_from ::FlexCommerceApi::Error::NotFound, ActionController::RoutingError,
+        with: :handle_resource_not_found
+    end
+
+    # default handler for API lookup 404 Not Found responses
+    def handle_resource_not_found(exception = nil)
+      redirect_params = redirect_lookup_params.merge(source_path: request.path)
+      # attempt to locate a matching redirect
+      redirect = FlexCommerce::Redirect.find_by_resource(redirect_params)
+      # if found, build URL and redirect
+      if redirect
+        redirect_url = destination_for_redirect(redirect)
+        redirect_to redirect_url, status: redirect.status_code
+      else
+        log_exception(exception)
+        handle_not_found(exception)
+      end
+    # when redirects cannot be found, handle using regular 404 process
+    rescue ::FlexCommerceApi::Error::NotFound => ex
+      log_exception(ex)
+      handle_not_found(exception)
+    end
+
+    # default behavior for handling not found errors, easily overridable and reusable
+    def handle_not_found(exception = nil)
+      raise(exception)
+    end
+
+    protected
+
+    # receives a FlexCommerce::Redirect object and returns a path to redirect to
+    def destination_for_redirect(redirect)
+      case redirect.destination_type
+      when "exact".freeze
+        redirect.destination_path
+      when "products".freeze, "static_pages".freeze, "categories".freeze
+        generate_url_for(redirect.destination_slug)
+      else
+        raise NotImplementedError, "Unknown redirect type '#{redirect.destination_type}'\n  #{redirect.inspect}"
+      end
+    end
+
+    private
+
+    # to be overridden by resource-based controllers to pass source_type and source_slug
+    def redirect_lookup_params
+      {}
+    end
+
+    def log_exception(ex)
+      return unless ex
+      # log the exception
+      Rails.logger.error(ex)
+      # log the exception with Sentry, if available
+      Raven.capture_exception(ex) if defined?(Raven)
+    end
+  end
+end

--- a/app/controllers/concerns/shift_commerce/resource_url.rb
+++ b/app/controllers/concerns/shift_commerce/resource_url.rb
@@ -1,0 +1,36 @@
+#
+# ResourceUrl
+#
+# Responsibility: Includes helper methods for generating a resource's url using it's slug.
+#
+module ShiftCommerce
+  module ResourceUrl
+    extend ActiveSupport::Concern
+
+    private
+
+    def generate_url_for(path, params = false)
+      @params ||= generate_params_from_string(params) if params.is_a? String
+      if @params.present?
+        @params.delete_if { |k,v| k == "action".freeze || k == "controller".freeze || k == "id".freeze || k == "slug_parts".freeze }
+        @stringified_params ||= @params.inject([]) { |s, (key, value)| s << "#{key}=#{URI.escape(value.to_s)}" }.join("&".freeze)
+      end
+      path = "/#{path}" if path[0] != "/".freeze
+      [path, @stringified_params].compact.join('?'.freeze)
+    end
+
+    def generate_absolute_url_for(path, params = false)
+      generate_url_for(path, params)[1..-1].prepend(root_url)
+    end
+
+    def generate_params_from_string(string)
+      @options ||= string.split('&'.freeze)
+      hash = @options.inject({}) do |hash, option|
+        key,value = option.split('='.freeze)
+        hash[key] = value
+        hash
+      end
+    end
+
+  end
+end

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.4.4'
+  VERSION = '0.4.6'
 end

--- a/spec/concerns/not_found_redirects_spec.rb
+++ b/spec/concerns/not_found_redirects_spec.rb
@@ -1,0 +1,139 @@
+require 'rails_helper'
+
+class NotFoundRedirectsController < ApplicationController
+  include ShiftCommerce::NotFoundRedirects
+  include ShiftCommerce::ResourceUrl
+
+  def index
+    get_static_page
+    render empty: true
+  end
+
+  private
+
+  def get_static_page
+    FlexCommerce::StaticPage.includes([]).find(1).first
+  end
+
+  # Overrides NotFoundRedirects#handle_not_found
+  # Avoid the test being stopped prematureiy by a real exception.
+  def handle_not_found(exception = nil)
+    false
+  end
+end
+
+describe ShiftCommerce::NotFoundRedirects, type: :controller do
+
+  before do
+    stub_request(:get, /.*\/testaccount\/v1\/static_pages\/1\.json_api/).
+      to_return(status: 404, body: '', headers: { 'Content-Type': 'application/vnd.api+json' })
+
+    @controller = NotFoundRedirectsController.new
+
+    Rails.application.routes.draw do
+      get '/' => 'not_found_redirects#index'
+    end
+  end
+
+  context 'when accessing a nonexistent resource' do
+    context 'with a valid exact path redirect' do
+      before do
+        EXACT_REDIRECT = {
+          data: {
+            "id": "1",
+            "type": "redirects",
+            "links": {
+              "self": "/testaccount/v1/redirects/1.json_api"
+            },
+            "attributes": {
+              "name": "Redirect Name",
+              "status_code": 301,
+              "priority": 0,
+              "source_type": "exact",
+              "destination_type": "exact",
+              "source_path": "/",
+              "source_slug": "",
+              "destination_path": "/somewhere_else",
+              "destination_slug": ""
+            }
+          },
+          meta: {
+            total_entries: 1,
+            page_count: 1
+          },
+          links: []
+        }.to_json.freeze
+
+        stub_request(:get, /.*\/testaccount\/v1\/redirects\.json_api/).
+        to_return(status: 200, body: EXACT_REDIRECT, headers: { 'Content-Type': 'application/vnd.api+json' })
+      end
+
+      it "should redirect correctly" do
+        get :index
+
+        expect(response).to redirect_to '/somewhere_else'
+      end
+    end
+
+    context 'with a valid resource redirect' do
+      before do
+        RESOURCE_REDIRECT = {
+          data: {
+            "id": "1",
+            "type": "redirects",
+            "links": {
+              "self": "/testaccount/v1/redirects/1.json_api"
+            },
+            "attributes": {
+              "name": "Redirect Name",
+              "status_code": 301,
+              "priority": 0,
+              "source_type": "exact",
+              "destination_type": "products",
+              "source_path": "/",
+              "source_slug": "",
+              "destination_path": "",
+              "destination_slug": "/products/1"
+            }
+          },
+          meta: {
+            total_entries: 1,
+            page_count: 1
+          },
+          links: []
+        }.to_json.freeze
+
+        stub_request(:get, /.*\/testaccount\/v1\/redirects\.json_api/).
+        to_return(status: 200, body: RESOURCE_REDIRECT, headers: { 'Content-Type': 'application/vnd.api+json' })
+      end
+
+      it "should redirect correctly" do
+        get :index
+
+        expect(response).to redirect_to '/products/1'
+      end
+    end
+
+
+    context 'with no redirect' do
+      before do
+        EMPTY_REDIRECT = {
+          data: [],
+          meta: {
+            total_entries: 0,
+            page_count: 0
+          },
+          links: []
+        }.to_json.freeze
+
+        stub_request(:get, /.*\/testaccount\/v1\/redirects\.json_api/).
+        to_return(status: 200, body: EMPTY_REDIRECT, headers: { 'Content-Type': 'application/vnd.api+json' })
+      end
+
+      it "should raise an exception" do
+        expect { controller.send(:get_static_page) }.to raise_error(FlexCommerceApi::Error::NotFound)
+      end
+    end
+  end
+
+end

--- a/spec/concerns/resource_url_spec.rb
+++ b/spec/concerns/resource_url_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+class ResourceUrlController < ApplicationController
+  include ShiftCommerce::ResourceUrl
+
+  # override, as we don't have access to the real root_url here
+  def root_url
+    'http://localhost/'
+  end
+end
+
+describe ShiftCommerce::ResourceUrl, type: :controller do
+
+  before do
+    @controller = ResourceUrlController.new
+
+    Rails.application.routes.draw do
+      root to: 'resource_url#index'
+    end
+  end
+
+  context 'generate_url_for' do
+    it "should output a valid relative URL, stripping unwanted parameters" do
+      path = '/path'
+      params = "foo=bar&action=deleteme&baz=bat"
+
+      expect(controller.send(:generate_url_for, path, params)).to eq('/path?foo=bar&baz=bat')
+    end
+  end
+
+  context 'generate_absolute_url_for' do
+    it "should output a valid absolute URL, stripping unwanted parameters" do
+      path = '/path'
+      params = "foo=bar&action=deleteme&baz=bat"
+
+      expect(controller.send(:generate_absolute_url_for, path, params)).to eq('http://localhost/path?foo=bar&baz=bat')
+    end
+  end
+
+end


### PR DESCRIPTION
This PR extracts the NotFoundRedirects concern from the frontend codebase, and includes it in this gem. It implements tests to ensure the concern is working correctly. 

As the ResourceUrl concern is a prerequisite for this concern, this PR also extracts it and includes specs to ensure the two methods it exposes work correctly.