### PR TITLE
Revert use of menu canonical path

### DIFF
--- a/app/helpers/shift_commerce/menu_items_helper.rb
+++ b/app/helpers/shift_commerce/menu_items_helper.rb
@@ -10,7 +10,7 @@ module ShiftCommerce
     end
 
     def url_for_menu_item(menu_item)
-      return menu_item.canonical_path
+      return menu_item.path
     end
   end
 end

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.5.2'
+  VERSION = '0.5.3'
 end


### PR DESCRIPTION
PR reverts the use of `canonical_path` for menus as this is dependent on B/E slug updates.