### PR TITLE
Update static pages controller to use local variables

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    shiftcommerce-rails (0.5.2)
+    shiftcommerce-rails (0.5.4)
       activemerchant (~> 1.54)
       meta-tags (~> 2.3.1)
       rails (~> 4.2.7)

--- a/app/controllers/shift_commerce/static_pages_controller.rb
+++ b/app/controllers/shift_commerce/static_pages_controller.rb
@@ -29,7 +29,7 @@ module ShiftCommerce
     end
 
     def static_page
-      ::FlexCommerce::StaticPage.includes(API_STATIC_PAGE_INCLUDES).find(params[:id]).first
+      @static_page ||= ::FlexCommerce::StaticPage.includes(API_STATIC_PAGE_INCLUDES).find(params[:id]).first
     end
 
   end

--- a/app/controllers/shift_commerce/static_pages_controller.rb
+++ b/app/controllers/shift_commerce/static_pages_controller.rb
@@ -7,30 +7,29 @@ module ShiftCommerce
     API_STATIC_PAGE_INCLUDES = "template_definition,meta.*".freeze
 
     def show
-      fetch_static_page
       set_static_page_meta_tags
       render_static_page
     end
 
     private
 
-    def fetch_static_page
-      @static_page = ::FlexCommerce::StaticPage.includes(API_STATIC_PAGE_INCLUDES).find(params[:id]).first
-    end
-
     def set_static_page_meta_tags
-      set_meta_tags title: @static_page.meta_attribute(:meta_title_override) || @static_page.title,
-                    canonical: generate_absolute_url_for(@static_page.slug),
-                    description: @static_page.meta_attribute(:meta_description),
-                    keywords: @static_page.meta_attribute(:keywords)
+      set_meta_tags title: static_page.meta_attribute(:meta_title_override) || static_page.title,
+                    canonical: generate_absolute_url_for(static_page.slug),
+                    description: static_page.meta_attribute(:meta_description),
+                    keywords: static_page.meta_attribute(:keywords)
     end
 
     def render_static_page
-      if @static_page.published == true
-        render_template_for @static_page
+      if static_page.published == true
+        render locals: { static_page: static_page }
       else
         handle_resource_not_found
       end
+    end
+
+    def static_page
+      ::FlexCommerce::StaticPage.includes(API_STATIC_PAGE_INCLUDES).find(params[:id]).first
     end
 
   end

--- a/app/controllers/shift_commerce/static_pages_controller.rb
+++ b/app/controllers/shift_commerce/static_pages_controller.rb
@@ -22,7 +22,7 @@ module ShiftCommerce
 
     def render_static_page
       if static_page.published == true
-        render locals: { static_page: static_page }
+        render_template_for static_page, locals: { static_page: static_page }
       else
         handle_resource_not_found
       end

--- a/app/views/shift_commerce/static_pages/show.html.erb
+++ b/app/views/shift_commerce/static_pages/show.html.erb
@@ -1,9 +1,9 @@
-<% if @static_page %>
-    <% shift_cache @static_page do %>
-        <h1><%= @static_page.title %></h1>
+<% if static_page %>
+    <% shift_cache static_page do %>
+        <h1><%= static_page.title %></h1>
         <div class="container" role="main">
             <div class="row">
-              <%= @static_page.body_content.html_safe %>
+              <%= static_page.body_content.html_safe %>
             </div>
         </div>
     <% end %>

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.5.3'
+  VERSION = '0.5.4'
 end


### PR DESCRIPTION
Replaces the instance variables in the static pages controller with local variables instead, in order to maintain compatibility with the existing F/E views. 

This change has been made as a correction of the previous method used to replace Decent Exposure, to prevent an extra dependency being added to the Rails gem.