### PR TITLE
Add 'connect-src' directive to CSP default policy

### DIFF
--- a/app/controllers/concerns/shift_commerce/content_security_policy.rb
+++ b/app/controllers/concerns/shift_commerce/content_security_policy.rb
@@ -15,7 +15,8 @@ module ShiftCommerce
       'style-src': ["'self'"],
       'font-src': ["'self'"],
       'child-src': ["'none'"],
-      'frame-ancestors': ["'none'"]
+      'frame-ancestors': ["'none'"],
+      'connect-src': ["'self'"]
     }.with_indifferent_access.freeze
 
     included do

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.5.6'
+  VERSION = '0.5.7'
 end

--- a/spec/concerns/content_security_policy_spec.rb
+++ b/spec/concerns/content_security_policy_spec.rb
@@ -25,7 +25,7 @@ describe ShiftCommerce::ContentSecurityPolicy, type: :controller do
     end
 
     it "should have the correct Content Security Policy" do
-      expect(csp_header).to include("default-src 'self'")
+      expect(csp_header).to include("default-src 'self';")
       expect(csp_header).to include("base-uri 'self';")
       expect(csp_header).to include("object-src 'none';")
       expect(csp_header).to include("img-src 'self' data:;")
@@ -33,7 +33,8 @@ describe ShiftCommerce::ContentSecurityPolicy, type: :controller do
       expect(csp_header).to include("style-src 'self';")
       expect(csp_header).to include("font-src 'self';")
       expect(csp_header).to include("child-src 'none';")
-      expect(csp_header).to include("frame-ancestors 'none'")
+      expect(csp_header).to include("frame-ancestors 'none';")
+      expect(csp_header).to include("connect-src 'self'")
     end
   end
 end


### PR DESCRIPTION
PR simply adds the `connect-src` directive to the CSP default policy. This directive resolves:

********************
<img width="1370" alt="screen shot 2017-01-12 at 10 37 54" src="https://cloud.githubusercontent.com/assets/4486874/21887818/6c5b2fc0-d8b9-11e6-9885-7aaee4852684.png">

