### PR TITLE
Static page title fallback

### DIFF
--- a/app/controllers/shift_commerce/static_pages_controller.rb
+++ b/app/controllers/shift_commerce/static_pages_controller.rb
@@ -14,7 +14,7 @@ module ShiftCommerce
     private
 
     def set_static_page_meta_tags
-      set_meta_tags title: static_page.meta_attribute(:meta_title_override) || static_page.title,
+      set_meta_tags title: static_page.meta_attribute(:meta_title_override).presence || static_page.title,
                     canonical: generate_absolute_url_for(static_page.slug),
                     description: static_page.meta_attribute(:meta_description),
                     keywords: static_page.meta_attribute(:keywords)


### PR DESCRIPTION
This PR ensures that static page titles fall back to the title of the page itself, if the `meta_title_override` field does not exist or is not set.