### PR TITLE
Update Static Page meta-tags

### DIFF
--- a/app/controllers/shift_commerce/static_pages_controller.rb
+++ b/app/controllers/shift_commerce/static_pages_controller.rb
@@ -33,7 +33,8 @@ module ShiftCommerce
     end
 
     def static_page_canonical
-      static_page.meta_attribute(:meta_canonical_override).presence || generate_absolute_url_for(static_page.slug)
+      canonical_path = static_page.meta_attribute(:meta_canonical_override).presence  || static_page.canonical_path
+      generate_absolute_url_for(canonical_path)
     end
 
     def static_page_keywords

--- a/app/controllers/shift_commerce/static_pages_controller.rb
+++ b/app/controllers/shift_commerce/static_pages_controller.rb
@@ -3,7 +3,7 @@ module ShiftCommerce
 
     include ShiftCommerce::TemplateDefinitionHelper
     include ShiftCommerce::CheckCanonicalPath
-    
+
     cache_shared_page only: :show
 
     API_STATIC_PAGE_INCLUDES = "template,meta.*".freeze
@@ -18,10 +18,26 @@ module ShiftCommerce
     private
 
     def set_static_page_meta_tags
-      set_meta_tags title: static_page.meta_attribute(:meta_title_override).presence || static_page.title,
-                    canonical: generate_absolute_url_for(static_page.slug),
-                    description: static_page.meta_attribute(:meta_description),
-                    keywords: static_page.meta_attribute(:keywords)
+      set_meta_tags title: static_page_title,
+                    canonical: static_page_canonical,
+                    description: static_page_description,
+                    keywords: static_page_keywords
+    end
+
+    def static_page_title
+       static_page.meta_attribute(:meta_title_override).presence || static_page.title
+    end
+
+    def static_page_description
+      static_page.meta_attribute(:meta_description).presence
+    end
+
+    def static_page_canonical
+      static_page.meta_attribute(:meta_canonical_override).presence || generate_absolute_url_for(static_page.slug)
+    end
+
+    def static_page_keywords
+      static_page.meta_attribute(:keywords).presence
     end
 
     def render_static_page

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.5.13'
+  VERSION = '0.5.14'
 end

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.5.12'
+  VERSION = '0.5.13'
 end


### PR DESCRIPTION
PR updates Static Page `description` and `canonical` meta-tags. 

ISSUE: https://github.com/shiftcommerce/matalan-rails-site/issues/1621

TESTED ADDED HERE - https://github.com/shiftcommerce/matalan-rails-site/pull/1625