### PR TITLE
Feature/remove logging 404

### DIFF
--- a/app/controllers/concerns/shift_commerce/not_found_redirects.rb
+++ b/app/controllers/concerns/shift_commerce/not_found_redirects.rb
@@ -21,12 +21,10 @@ module ShiftCommerce
         redirect_url = redirect.destination_path
         redirect_to redirect_url, status: redirect.status_code
       else
-        log_exception(exception)
         handle_not_found(exception)
       end
     # when redirects cannot be found, handle using regular 404 process
     rescue ::FlexCommerceApi::Error::NotFound => ex
-      log_exception(ex)
       handle_not_found(exception)
     end
 
@@ -34,15 +32,6 @@ module ShiftCommerce
     def handle_not_found(exception = nil)
       raise(exception)
     end
-
-    private
-
-    def log_exception(ex)
-      return unless ex
-      # log the exception
-      Rails.logger.error(ex)
-      # log the exception with Sentry, if available
-      Raven.capture_exception(ex) if defined?(Raven)
-    end
+  
   end
 end

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.5.16'
+  VERSION = '0.5.17'
 end


### PR DESCRIPTION
Removed the log_exception method, which was used in logging 404s in the page.
Updated the gem version to '0.5.17'