### PR TITLE
Hotfix: Asset preloading issue (#1750)

### DIFF
--- a/app/controllers/concerns/shift_commerce/asset_push.rb
+++ b/app/controllers/concerns/shift_commerce/asset_push.rb
@@ -24,8 +24,8 @@ module ShiftCommerce
     end
 
     def asset_type(path)
-      extention_name = File.extname(path)
-      case extention_name
+      file_extention = File.extname(path)
+      case file_extention
       when ".js"  then "as=script"
       when ".css" then "as=stylesheet"
       else return

--- a/app/controllers/concerns/shift_commerce/asset_push.rb
+++ b/app/controllers/concerns/shift_commerce/asset_push.rb
@@ -23,6 +23,7 @@ module ShiftCommerce
       raise NotImplementedError, "to use asset push, you must define #push_assets"
     end
 
+    # determines the asset type using its extension
     def asset_type(path)
       file_extention = File.extname(path)
       case file_extention

--- a/app/controllers/concerns/shift_commerce/asset_push.rb
+++ b/app/controllers/concerns/shift_commerce/asset_push.rb
@@ -26,7 +26,7 @@ module ShiftCommerce
     def asset_type(path)
       extention_name = File.extname(path)
       case extention_name
-      when ".js" then "as=script"
+      when ".js"  then "as=script"
       when ".css" then "as=stylesheet"
       else return
       end

--- a/app/controllers/concerns/shift_commerce/asset_push.rb
+++ b/app/controllers/concerns/shift_commerce/asset_push.rb
@@ -14,7 +14,7 @@ module ShiftCommerce
     def add_preload_headers
       response.headers['Link'] ||= []
       Array(push_assets).each do |path|
-        response.headers['Link'].push("<#{view_context.asset_path(path)}>; rel=preload; #{asset_type(path)}")
+        response.headers['Link'].push("<#{view_context.asset_path(path)}>; rel=preload; as=#{asset_type(path)}")
       end
     end
 
@@ -26,8 +26,8 @@ module ShiftCommerce
     def asset_type(path)
       file_extention = File.extname(path)
       case file_extention
-      when ".js"  then "as=script"
-      when ".css" then "as=stylesheet"
+      when ".js"  then "script"
+      when ".css" then "stylesheet"
       else return
       end
     end

--- a/app/controllers/concerns/shift_commerce/asset_push.rb
+++ b/app/controllers/concerns/shift_commerce/asset_push.rb
@@ -14,13 +14,22 @@ module ShiftCommerce
     def add_preload_headers
       response.headers['Link'] ||= []
       Array(push_assets).each do |path|
-        response.headers['Link'].push("<#{view_context.asset_path(path)}>; rel=preload")
+        response.headers['Link'].push("<#{view_context.asset_path(path)}>; rel=preload; #{asset_type(path)}")
       end
     end
 
     # these should only be non-async assets used in <head>
     def push_assets
       raise NotImplementedError, "to use asset push, you must define #push_assets"
+    end
+
+    def asset_type(path)
+      extention_name = File.extname(path)
+      case extention_name
+      when ".js" then "as=script"
+      when ".css" then "as=stylesheet"
+      else return
+      end
     end
   end
 end

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.5.17'
+  VERSION = '0.5.18'
 end

--- a/spec/concerns/asset_push_spec.rb
+++ b/spec/concerns/asset_push_spec.rb
@@ -12,7 +12,7 @@ class AssetPushWithAssetsController < AssetPushController
   private
 
   def push_assets
-    ['foo', 'bar']
+    ['foo.js', 'bar.css']
   end
 end
 
@@ -30,8 +30,8 @@ describe ShiftCommerce::AssetPush, type: :controller do
     it "should set the Link header with the contents of push_assets" do
       get :index
 
-      expect(response.header['Link']).to include('</foo>; rel=preload')
-      expect(response.header['Link']).to include('</bar>; rel=preload')
+      expect(response.header['Link']).to include('</foo.js>; rel=preload; as=script')
+      expect(response.header['Link']).to include('</bar.css>; rel=preload; as=stylesheet')
     end
   end
 


### PR DESCRIPTION
PR addresses issue https://github.com/shiftcommerce/matalan-rails-site/issues/1750

The `as` option was missing when setting the Link headers for preloading assets. As such, the assets were being fetched twice.

** Gem version to be updated in the F/E app after its released

************
#### BEFORE (https://prerel-matalanb.shiftpreview.com/?site_password=batman)

<img width="1302" alt="screen shot 2017-05-16 at 10 00 11" src="https://cloud.githubusercontent.com/assets/4486874/26098911/1ded2b4e-3a21-11e7-9e14-7bee208da495.png">

<img width="1296" alt="screen shot 2017-05-16 at 09 58 52" src="https://cloud.githubusercontent.com/assets/4486874/26098964/408a48b2-3a21-11e7-84c6-0fe32001fe0a.png">

************
#### AFTER (https://mmassets-matalanb.shiftpreview.com/?site_password=batman)

<img width="1369" alt="screen shot 2017-05-16 at 09 59 48" src="https://cloud.githubusercontent.com/assets/4486874/26098938/303a3c60-3a21-11e7-9cce-f512d6b12601.png">
<img width="1371" alt="screen shot 2017-05-16 at 09 59 23" src="https://cloud.githubusercontent.com/assets/4486874/26098957/3acd898e-3a21-11e7-80c2-1487491e9fc0.png">

