### PR TITLE
Updated rel=preload types

### DIFF
--- a/app/controllers/concerns/shift_commerce/asset_push.rb
+++ b/app/controllers/concerns/shift_commerce/asset_push.rb
@@ -28,7 +28,7 @@ module ShiftCommerce
       file_extention = File.extname(path)
       case file_extention
       when ".js"  then "script"
-      when ".css" then "stylesheet"
+      when ".css" then "style"
       else return
       end
     end

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.5.18'
+  VERSION = '0.5.19'
 end

--- a/spec/concerns/asset_push_spec.rb
+++ b/spec/concerns/asset_push_spec.rb
@@ -31,7 +31,7 @@ describe ShiftCommerce::AssetPush, type: :controller do
       get :index
 
       expect(response.header['Link']).to include('</foo.js>; rel=preload; as=script')
-      expect(response.header['Link']).to include('</bar.css>; rel=preload; as=stylesheet')
+      expect(response.header['Link']).to include('</bar.css>; rel=preload; as=style')
     end
   end
 


### PR DESCRIPTION
Currently we're sending the wrong `as` property for `Link: rel=preload` headers for stylesheets, we send `as=stylesheet` when it should be `as=style`, hence why we get this error:

![screen shot 2017-05-25 at 14 02 00](https://cloud.githubusercontent.com/assets/12299/26451168/c881aeb2-4152-11e7-95a4-6a3e4105a244.png)

See spec: https://w3c.github.io/preload/#h-link-element-interface-extensions