### PR TITLE
Removed FASTLY_ENABLE_ESI check

### DIFF
--- a/app/controllers/concerns/shift_commerce/http_caching.rb
+++ b/app/controllers/concerns/shift_commerce/http_caching.rb
@@ -40,7 +40,7 @@ module ShiftCommerce
         yield
       end
 
-      if surrogate_keys.present? && ENV['FASTLY_ENABLE_ESI']
+      if surrogate_keys.present?
         response.headers['Surrogate-Key'] = surrogate_keys.split(' ').reject { |k| k.include?('menu_item') }.join(' ')
         response.headers['Surrogate-Control'] = 'max-age=3600,stale-if-error=86400,stale-while-revalidate=86400'
         response.headers['Cache-Control'] = 'max-age=0, must-revalidate'

--- a/spec/concerns/http_caching_spec.rb
+++ b/spec/concerns/http_caching_spec.rb
@@ -55,8 +55,6 @@ describe ShiftCommerce::HttpCaching, type: :controller do
       Rails.application.routes.draw do
         get '/http_caching_shared' => 'http_caching_with_shared_page#index'
       end
-
-      ENV['FASTLY_ENABLE_ESI'] = 'true'
     end
 
     it "should apply surrogate keys correctly" do
@@ -80,8 +78,6 @@ describe ShiftCommerce::HttpCaching, type: :controller do
       Rails.application.routes.draw do
         get '/http_caching_private' => 'http_caching_with_private_page#index'
       end
-
-      ENV['FASTLY_ENABLE_ESI'] = 'true'
     end
 
     it "should apply surrogate keys correctly" do


### PR DESCRIPTION
This isn't a bug now, but could become one in future – if someone forgets the FASTLY_ENABLE_ESI ENV var, then Fastly caching would be disabled entirely.
