### PR TITLE
Bug fix: Only add `Link` header when we're HTTP/2 pushing at least 1 asset

### DIFF
--- a/app/controllers/concerns/shift_commerce/asset_push.rb
+++ b/app/controllers/concerns/shift_commerce/asset_push.rb
@@ -12,9 +12,12 @@ module ShiftCommerce
 
     # appends a Link header for each asset that's due to be pushed
     def add_preload_headers
-      response.headers['Link'] ||= []
-      Array(push_assets).each do |path|
-        response.headers['Link'].push("<#{view_context.asset_path(path)}>; rel=preload; as=#{asset_type(path)}")
+      assets_to_push = Array(push_assets)
+      if assets_to_push.any?
+        response.headers['Link'] ||= []
+        assets_to_push.each do |path|
+          response.headers['Link'].push("<#{view_context.asset_path(path)}>; rel=preload; as=#{asset_type(path)}")
+        end
       end
     end
 


### PR DESCRIPTION
When we opt not to push any assets, we're setting an empty `Link` header, rather than not sending one at all.

This PR corrects this behaviour.