### PR TITLE
updated menus_cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gemspec
 # your gem to rubygems.org.
 
 # Shift Commerce gem
-gem "flex_commerce_api", git: "https://github.com/flex-commerce/flex-ruby-gem.git", tag: 'v0.6.45'
+gem "flex_commerce_api", git: "https://github.com/flex-commerce/flex-ruby-gem.git", tag: 'v0.6.43'
 
 group :development, :test do
   # Debugging tools

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gemspec
 # your gem to rubygems.org.
 
 # Shift Commerce gem
-gem "flex_commerce_api", git: "https://github.com/flex-commerce/flex-ruby-gem.git", tag: 'v0.6.29'
+gem "flex_commerce_api", git: "https://github.com/flex-commerce/flex-ruby-gem.git", tag: 'v0.6.45'
 
 group :development, :test do
   # Debugging tools

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    shiftcommerce-rails (0.6.0)
+    shiftcommerce-rails (0.6.3)
       activemerchant (~> 1.54)
       meta-tags (~> 2.4)
       rails (~> 5.1)
@@ -47,8 +47,8 @@ GEM
     activejob (5.1.2)
       activesupport (= 5.1.2)
       globalid (>= 0.3.6)
-    activemerchant (1.68.0)
-      activesupport (>= 3.2.14, < 6.x)
+    activemerchant (1.80.0)
+      activesupport (>= 4.2, < 6.x)
       builder (>= 2.1.2, < 4.0.0)
       i18n (>= 0.6.9)
       nokogiri (~> 1.4)
@@ -80,7 +80,7 @@ GEM
       faraday (~> 0.8)
     faraday_middleware (0.11.0.1)
       faraday (>= 0.7.4, < 1.0)
-    globalid (0.4.0)
+    globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashdiff (0.3.4)
     i18n (0.8.4)
@@ -92,18 +92,16 @@ GEM
       faraday_middleware (~> 0.9)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    mail (2.6.6)
-      mime-types (>= 1.16, < 4)
-    meta-tags (2.4.1)
-      actionpack (>= 3.2.0, < 5.2)
+    mail (2.7.0)
+      mini_mime (>= 0.1.1)
+    meta-tags (2.10.0)
+      actionpack (>= 3.2.0, < 5.3)
     method_source (0.8.2)
-    mime-types (3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mini_mime (1.0.0)
     mini_portile2 (2.2.0)
     minitest (5.10.2)
     multipart-post (2.0.0)
-    nio4r (2.1.0)
+    nio4r (2.3.1)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
     oj (2.18.5)
@@ -163,10 +161,10 @@ GEM
     rspec-support (3.6.0)
     safe_yaml (1.0.4)
     slop (3.6.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.0)
+    sprockets-rails (3.2.1)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -180,7 +178,7 @@ GEM
       hashdiff
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
+    websocket-extensions (0.1.3)
 
 PLATFORMS
   ruby
@@ -194,4 +192,4 @@ DEPENDENCIES
   webmock (~> 1.24.2)
 
 BUNDLED WITH
-   1.15.1
+   1.15.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/flex-commerce/flex-ruby-gem.git
-  revision: a80c679070979db59095942e521ec1256d6713cc
-  tag: v0.6.29
+  revision: 2e56e8c503b925c09422c47e8fa2d4c5b65fddab
+  tag: v0.6.45
   specs:
-    flex_commerce_api (0.6.29)
+    flex_commerce_api (0.6.45)
       activesupport (>= 4.0)
       faraday-http-cache (= 1.3.0)
       json_api_client (= 1.1.1)
@@ -74,11 +74,11 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     erubi (1.6.1)
-    faraday (0.12.1)
+    faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.0)
       faraday (~> 0.8)
-    faraday_middleware (0.11.0.1)
+    faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)

--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -5,16 +5,17 @@ module ShiftCommerce
       cache(shift_cache_key object, *args) { yield }
     end
 
-    def menus_cache(reference)
+    def menus_cache(reference, banner_reference = nil)
       menu = all_menus_cache[reference] || MissingMenu.new(reference)
       return yield if menu.nil?
-      multi_cache(shift_cache_key(menu)) { yield if block_given? }
+      multi_cache(shift_cache_key(menu, banner_reference)) { yield if block_given? }
     end
 
     private
 
-    def shift_cache_key object
-      [object.class.name, object.id, object.updated_at.to_datetime.utc.to_i.to_s].join("/")
+    def shift_cache_key(object, banner_reference)
+      object_id = banner_reference == nil ? menu.id : banner_reference
+      [object.class.name, object_id, object.updated_at.to_datetime.utc.to_i.to_s].join("/")
     end
   end
 end

--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -13,7 +13,7 @@ module ShiftCommerce
 
     private
 
-    def shift_cache_key(object, banner_reference = nil)
+    def shift_cache_key(object, banner_reference)
       object_id = banner_reference == nil ? object.id : banner_reference
       [object.class.name, object_id, object.updated_at.to_datetime.utc.to_i.to_s].join("/")
     end

--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -14,7 +14,7 @@ module ShiftCommerce
     private
 
     def shift_cache_key(object, banner_reference)
-      object_id = banner_reference == nil ? menu.id : banner_reference
+      object_id = banner_reference == nil ? object.id : banner_reference
       [object.class.name, object_id, object.updated_at.to_datetime.utc.to_i.to_s].join("/")
     end
   end

--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -13,7 +13,7 @@ module ShiftCommerce
 
     private
 
-    def shift_cache_key(object, banner_reference)
+    def shift_cache_key(object, banner_reference = nil)
       object_id = banner_reference == nil ? object.id : banner_reference
       [object.class.name, object_id, object.updated_at.to_datetime.utc.to_i.to_s].join("/")
     end


### PR DESCRIPTION
Update is required so that the `menus_cache` method takes and optional parameter so that in the matalan front end we can pass the different banner titles as well as the banner references making the cache keys unique so that all the different banners are cached.