### PR TITLE
Feature: Make #generate_absolute_url_for available to views, not just controllers

### DIFF
--- a/app/controllers/concerns/shift_commerce/resource_url.rb
+++ b/app/controllers/concerns/shift_commerce/resource_url.rb
@@ -6,6 +6,10 @@
 module ShiftCommerce
   module ResourceUrl
     extend ActiveSupport::Concern
+    
+    included do
+      helper_method :generate_absolute_url_for
+    end
 
     private
 

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.6.2'
+  VERSION = '0.6.3'
 end


### PR DESCRIPTION
Currently you can't use `generate_absolute_url_for` outside of controllers, this change makes it a helper method that can be accessed in views.