### PR TITLE
Issue/Menu items can't be previewed

### DIFF
--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -7,7 +7,7 @@ module ShiftCommerce
 
     def menus_cache(reference)
       # Dont fetch from cache if requested for a preview
-      return yield if params[:preview].present? && params[:preview] === 'true'
+      return yield if params[:preview] === 'true'
 
       # Fetch from cache for normal requests
       menu = all_menus_cache[reference] || MissingMenu.new(reference)

--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -7,7 +7,7 @@ module ShiftCommerce
 
     def menus_cache(reference)
       # Dont fetch from cache if requested for a preview
-      return yield if params[:preview].present?
+      return yield if params[:preview].present? && params[:preview] === 'true'
 
       # Fetch from cache for normal requests
       menu = all_menus_cache[reference] || MissingMenu.new(reference)

--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -6,6 +6,10 @@ module ShiftCommerce
     end
 
     def menus_cache(reference)
+      # Dont fetch from cache if requested for a preview
+      return yield if params[:preview].present?
+
+      # Fetch from cache for normal requests
       menu = all_menus_cache[reference] || MissingMenu.new(reference)
       return yield if menu.nil?
       multi_cache(shift_cache_key(menu)) { yield if block_given? }

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.6.3'
+  VERSION = '0.6.4'
 end


### PR DESCRIPTION
Related issue: https://github.com/shiftcommerce/matalan-rails-site/issues/2623

Even when we are requesting for a preview, we are retreiving data from cache, instead of api. This PR adds a condition to see if preview is requested and it is set to true.