### PR TITLE
Feature/Introduce Dependent caches in menus

### DIFF
--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -5,21 +5,35 @@ module ShiftCommerce
       cache(shift_cache_key object, *args) { yield }
     end
 
-    def menus_cache(reference, banner_reference = nil)
+    def menus_cache(references, banner_reference = nil)
       # Dont fetch from cache if requested for a preview
       return yield if params[:preview] === 'true'
 
-      # Fetch from cache for normal requests
-      menu = all_menus_cache[reference] || MissingMenu.new(reference)
-      return yield if menu.nil?
-      multi_cache(shift_cache_key(menu, banner_reference)) { yield if block_given? }
-    end
+      menus = []
+      Array(references).each do |reference|
+        menus.push(all_menus_cache[reference] || MissingMenu.new(reference))
+      end
 
+      return yield if menus.nil?
+
+      # Fetch from cache for normal requests
+      if references.kind_of?(Array)
+        multi_nested_cache(shift_cache_key(menus)) { yield if block_given? }
+      else
+        multi_cache(shift_cache_key(menus, banner_reference)) { yield if block_given? }
+      end
+    end
+  
     private
 
     def shift_cache_key(object, banner_reference = nil)
-      object_id = banner_reference == nil ? object.id : banner_reference
-      [object.class.name, object_id, object.updated_at.to_datetime.utc.to_i.to_s].join("/")
+      keys = []
+      Array(object).each do |menu|
+        object_id = banner_reference == nil ? menu.id : banner_reference
+        keys.push(["FlexCommerce::Menu", object_id, menu.updated_at.to_datetime.utc.to_i.to_s].join("/"))
+      end
+      keys
     end
+
   end
 end


### PR DESCRIPTION
Issue:

Related GitHub issue: [Comms#416](/shiftcommerce/matalan-comms/issues/416)

`menus_cache` should be supporting the dependent fragment caching in order to expire `gloabl_messages` banners cache as expected.

To test: Follow the description mentioned here: https://github.com/shiftcommerce/matalan-rails-site/pull/2809