### PR TITLE
Feature/Add expires_in logic to the menus_cache method

### DIFF
--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -5,14 +5,14 @@ module ShiftCommerce
       cache(shift_cache_key object, *args) { yield }
     end
 
-    def menus_cache(reference, banner_reference = nil)
+    def menus_cache(reference, banner_reference = nil, expires_in: nil)
       # Dont fetch from cache if requested for a preview
       return yield if params[:preview] === 'true'
 
       # Fetch from cache for normal requests
       menu = all_menus_cache[reference] || MissingMenu.new(reference)
       return yield if menu.nil?
-      multi_cache(shift_cache_key(menu, banner_reference)) { yield if block_given? }
+      multi_cache(shift_cache_key(menu, banner_reference), {expires_in: expires_in}) { yield if block_given? }
     end
 
     private

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.6.7'
+  VERSION = '0.6.8'
 end


### PR DESCRIPTION
This PR adds the ability to set `expires_in` option for the menus fragment cache. 