### PR TITLE
Prevent static page preview reading from cache

### DIFF
--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -1,7 +1,7 @@
 module ShiftCommerce
   module CacheHelper
     def shift_cache object, *args
-      return yield if object.nil?
+      return yield if object.nil? || params[:preview] === 'true'
       cache(shift_cache_key object, *args) { yield }
     end
 

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.6.9'
+  VERSION = '0.6.11'
 end


### PR DESCRIPTION
Related issue: https://shiftcommerce.zendesk.com/agent/tickets/116

When user trying to preview a static page, data is supposed to be read from API. But instead, it is getting read from cache.

This PR handles the situation by returning yield if the preview param is set to true.