### PR TITLE
Matalan-Comms/#535_updated title to name for the metadata

### DIFF
--- a/app/controllers/shift_commerce/bundles_controller.rb
+++ b/app/controllers/shift_commerce/bundles_controller.rb
@@ -80,7 +80,7 @@ module ShiftCommerce
     end
 
     def bundle_page_title
-      bundle.meta_attribute(:meta_title_override).presence || bundle.title
+      bundle.meta_attribute(:meta_title_override).presence || bundle.name
     end
 
     def bundle_page_description

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.6.11'
+  VERSION = '0.6.12'
 end


### PR DESCRIPTION
### Overview
Related GitHub issue: https://github.com/shiftcommerce/shift_commerce-rails/issues/59

### The issue
Currently the gem is looking for bundle.title instead of bundle.name returning a empty meta title on the page, unless an override had been added in the rails meta data. 

### QA
Pull the gem or change your gem file to point the `shiftcommerce-rails` gem to this branch. 
Check a product bundle `/bundles/mens-modern-take` 
Check the page has a metadata title 

Compare this the master bundle. 

### Code Review
1. app/controllers/shift_commerce/bundles_controller.rb - line 83
