### PR TITLE
Expose preview_mode_enabled? to views as helper method

### DIFF
--- a/app/controllers/concerns/shift_commerce/preview_state_management.rb
+++ b/app/controllers/concerns/shift_commerce/preview_state_management.rb
@@ -13,8 +13,13 @@ module ShiftCommerce
       # if caching was to be applied, prevent it
       skip_after_action :vary_page_caching_on_user, if: :preview_mode_enabled?, raise: false
       skip_around_action :capture_and_apply_surrogate_keys, if: :preview_mode_enabled?, raise: false
+      # expose #preview_mode_enabled? to views
+      helper_method :preview_mode_enabled?
     end
 
+    def preview_mode_enabled?
+      params[:preview].present?
+    end
 
     protected
 
@@ -26,10 +31,6 @@ module ShiftCommerce
       yield
     ensure
       FlexCommerceApi::ApiBase.reconfigure_all
-    end
-
-    def preview_mode_enabled?
-      params[:preview].present?
     end
   end
 end

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.6.11'
+  VERSION = '0.6.12'
 end


### PR DESCRIPTION
In this PR, we need access to `preview_mode_enabled?` in a view helper: https://github.com/shiftcommerce/matalan-rails-site/pull/3174

This PR simply adds it as a public helper method.