### PR TITLE
Issue/62 remove hard coded cache key

### DIFF
--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -28,7 +28,7 @@ module ShiftCommerce
     end
 
     private
-    # Object can be a FlexCommerce::Menu, FlexCommerce::StaticPage or any other resource we wish to cache.
+    # resource can be a FlexCommerce::Menu, FlexCommerce::StaticPage or any other resource we wish to cache.
     def shift_cache_key(resource, banner_reference = nil)
       keys = []
       Array(resource).each do |resource|

--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -28,12 +28,12 @@ module ShiftCommerce
     end
 
     private
-    # Object can be a menu, static_page or any other resource we wish to cache.
-    def shift_cache_key(object, banner_reference = nil)
+    # Object can be a FlexCommerce::Menu, FlexCommerce::StaticPage or any other resource we wish to cache.
+    def shift_cache_key(resource, banner_reference = nil)
       keys = []
-      Array(object).each do |object|
-        object_id = banner_reference == nil ? object.id : banner_reference
-        keys.push([object.class, object_id, object.updated_at.to_datetime.utc.to_i.to_s].join("/"))
+      Array(resource).each do |resource|
+        resource_id = banner_reference == nil ? resource.id : banner_reference
+        keys.push([resource.class, resource_id, resource.updated_at.to_datetime.utc.to_i.to_s].join("/"))
       end
       keys
     end

--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -26,14 +26,14 @@ module ShiftCommerce
         multi_dependent_cache(shift_cache_key(menus), options) { yield if block_given? }
       end
     end
-  
-    private
 
+    private
+    # Object can be a menu, static_page or any other resource we wish to cache.
     def shift_cache_key(object, banner_reference = nil)
       keys = []
-      Array(object).each do |menu|
-        object_id = banner_reference == nil ? menu.id : banner_reference
-        keys.push(["FlexCommerce::Menu", object_id, menu.updated_at.to_datetime.utc.to_i.to_s].join("/"))
+      Array(object).each do |object|
+        object_id = banner_reference == nil ? object.id : banner_reference
+        keys.push([object.class, object_id, object.updated_at.to_datetime.utc.to_i.to_s].join("/"))
       end
       keys
     end

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.6.12'
+  VERSION = '0.6.13'
 end


### PR DESCRIPTION
### The issue

Static pages are being cached and their key is prefixed with `FlexCommerce::Menu`

### The fix

Use object.class to generate the first part of the key. 

### QA

Follow QA steps in this PR https://github.com/shiftcommerce/matalan-rails-site/pull/3228