### PR TITLE
Matalan retail/#46 homepage redirect to root

### DIFF
--- a/app/controllers/shift_commerce/static_pages_controller.rb
+++ b/app/controllers/shift_commerce/static_pages_controller.rb
@@ -46,7 +46,7 @@ module ShiftCommerce
     end
 
     def render_static_page?
-      static_page.published == true && static_page.meta_attribute(:hide_static_page) == false
+      static_page.published == true
     end
   
     def render_static_page

--- a/app/controllers/shift_commerce/static_pages_controller.rb
+++ b/app/controllers/shift_commerce/static_pages_controller.rb
@@ -46,7 +46,7 @@ module ShiftCommerce
     end
 
     def render_static_page?
-      static_page.published == true && static_page.meta_attribute(:hide_static_page) = false
+      static_page.published == true && static_page.meta_attribute(:hide_static_page) == false
     end
   
     def render_static_page

--- a/app/controllers/shift_commerce/static_pages_controller.rb
+++ b/app/controllers/shift_commerce/static_pages_controller.rb
@@ -45,8 +45,12 @@ module ShiftCommerce
       static_page.meta_attribute(:keywords).presence
     end
 
+    def render_static_page?
+      static_page.published == true && static_page.meta_attribute(:hide_static_page) = false
+    end
+  
     def render_static_page
-      if static_page.published == true
+      if render_static_page?
         render_template_for static_page, locals: { static_page: static_page }
       else
         handle_resource_not_found

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.6.13'
+  VERSION = '0.6.14'
 end


### PR DESCRIPTION
## Overview

Related GitHub issue: https://github.com/matalan-retail-limited/matalan-rails-site/pull/57

## Changes 

I have added a function to check if the static_page has a meta_attribute of hide_static_page present, if so it will send handle resource not found. 

This allows us to handle the static page `/homepage` to hit the 404 page but this page has a redirect set up to the root. 

Originally created with wrong branch name: https://github.com/shiftcommerce/shift_commerce-rails/pull/70