### PR TITLE
Feature/Menu cache version

### DIFF
--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -6,6 +6,7 @@ module ShiftCommerce
     end
 
     def menus_cache(reference, cache_version = nil, banner_reference = nil, dependent_reference = nil, options = {})
+
       # Dont fetch from cache if requested for a preview
       return yield if params[:preview] === 'true'
 
@@ -29,7 +30,7 @@ module ShiftCommerce
 
     private
     # resource can be a FlexCommerce::Menu, FlexCommerce::StaticPage or any other resource we wish to cache.
-    def shift_cache_key(resource, cache_version, banner_reference = nil)
+    def shift_cache_key(resource, cache_version = nil, banner_reference = nil)
       keys = []
       Array(resource).each do |resource|
         resource_id = banner_reference == nil ? resource.id : banner_reference

--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -6,9 +6,6 @@ module ShiftCommerce
     end
 
     def menus_cache(reference, banner_reference = nil, dependent_reference = nil, options = {})
-      # Menu cache version
-      cache_version = menus_cache_version
-
       # Dont fetch from cache if requested for a preview
       return yield if params[:preview] === 'true'
 
@@ -21,6 +18,9 @@ module ShiftCommerce
 
       # If we dont find any in cache, then fetch via api
       return yield if menus.nil?
+
+      # Menu cache version
+      cache_version = menus_cache_version
 
       # Fetch from cache for normal requests
       if dependent_reference.nil?

--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -33,10 +33,11 @@ module ShiftCommerce
     private
 
     def menus_cache_version
+      default_version = "v1"
       if defined?(Menus) == 'constant' && Menus.class == Class
-        Menus.public_send(:menu_cache_version)
+        Menus&.menu_cache_version || default_version
       else
-        "v1"
+        default_version
       end
     end
 

--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -5,7 +5,7 @@ module ShiftCommerce
       cache(shift_cache_key object, *args) { yield }
     end
 
-    def menus_cache(reference, cache_version, banner_reference = nil, dependent_reference = nil, options = {})
+    def menus_cache(reference, cache_version = nil, banner_reference = nil, dependent_reference = nil, options = {})
       # Dont fetch from cache if requested for a preview
       return yield if params[:preview] === 'true'
 
@@ -33,7 +33,7 @@ module ShiftCommerce
       keys = []
       Array(resource).each do |resource|
         resource_id = banner_reference == nil ? resource.id : banner_reference
-        keys.push([resource.class, resource_id, cache_version, resource.updated_at.to_datetime.utc.to_i.to_s].join("/"))
+        keys.push([resource.class, resource_id, cache_version, resource.updated_at.to_datetime.utc.to_i.to_s].compact.join("/"))
       end
       keys
     end

--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -5,7 +5,9 @@ module ShiftCommerce
       cache(shift_cache_key object, *args) { yield }
     end
 
-    def menus_cache(reference, cache_version = nil, banner_reference = nil, dependent_reference = nil, options = {})
+    def menus_cache(reference, banner_reference = nil, dependent_reference = nil, options = {})
+      # Menu cache version
+      cache_version = menus_cache_version
 
       # Dont fetch from cache if requested for a preview
       return yield if params[:preview] === 'true'
@@ -29,6 +31,15 @@ module ShiftCommerce
     end
 
     private
+
+    def menus_cache_version
+      if defined?(Menus) == 'constant' && Menus.class == Class
+        Menus.public_send(:menu_cache_version)
+      else
+        "v1"
+      end
+    end
+
     # resource can be a FlexCommerce::Menu, FlexCommerce::StaticPage or any other resource we wish to cache.
     def shift_cache_key(resource, cache_version = nil, banner_reference = nil)
       keys = []

--- a/app/helpers/shift_commerce/cache_helper.rb
+++ b/app/helpers/shift_commerce/cache_helper.rb
@@ -5,7 +5,7 @@ module ShiftCommerce
       cache(shift_cache_key object, *args) { yield }
     end
 
-    def menus_cache(reference, banner_reference = nil, dependent_reference = nil, options = {})
+    def menus_cache(reference, cache_version, banner_reference = nil, dependent_reference = nil, options = {})
       # Dont fetch from cache if requested for a preview
       return yield if params[:preview] === 'true'
 
@@ -21,19 +21,19 @@ module ShiftCommerce
 
       # Fetch from cache for normal requests
       if dependent_reference.nil?
-        multi_cache(shift_cache_key(menus, banner_reference), options) { yield if block_given? }
+        multi_cache(shift_cache_key(menus, cache_version, banner_reference), options) { yield if block_given? }
       else
-        multi_dependent_cache(shift_cache_key(menus), options) { yield if block_given? }
+        multi_dependent_cache(shift_cache_key(menus, cache_version), options) { yield if block_given? }
       end
     end
 
     private
     # resource can be a FlexCommerce::Menu, FlexCommerce::StaticPage or any other resource we wish to cache.
-    def shift_cache_key(resource, banner_reference = nil)
+    def shift_cache_key(resource, cache_version, banner_reference = nil)
       keys = []
       Array(resource).each do |resource|
         resource_id = banner_reference == nil ? resource.id : banner_reference
-        keys.push([resource.class, resource_id, resource.updated_at.to_datetime.utc.to_i.to_s].join("/"))
+        keys.push([resource.class, resource_id, cache_version, resource.updated_at.to_datetime.utc.to_i.to_s].join("/"))
       end
       keys
     end

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.6.14'
+  VERSION = '0.6.15'
 end

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.6.13'
+  VERSION = '0.6.14'
 end


### PR DESCRIPTION
Related ticket: https://github.com/matalan-retail-limited/matalan-rails-site/issues/55

This PR introduces the ability to append the cache version string into the actual cache key for menus or in general for the resources which calls the method `shift_cache_key`. 

**Before**: `shift_cache_key(resource, banner_reference)`

**After**: `shift_cache_key(resource, cache_version, banner_reference)`

Same with the **menus_cache** method too:


**Before**: `menus_cache(reference, banner_reference , dependent_reference, options)`

**After**: `menus_cache(reference, cache_version, banner_reference, dependent_reference, options)