### PR TITLE
Cleanup/remove deprecate body content field

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    shiftcommerce-rails (0.6.7)
+    shiftcommerce-rails (0.6.17)
       activemerchant (~> 1.54)
       meta-tags (~> 2.4)
       rack-timeout (~> 0.5.1)
@@ -93,12 +93,12 @@ GEM
       faraday_middleware (~> 0.9)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    mail (2.7.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
     meta-tags (2.10.0)
       actionpack (>= 3.2.0, < 5.3)
     method_source (0.8.2)
-    mini_mime (1.0.0)
+    mini_mime (1.0.1)
     mini_portile2 (2.2.0)
     minitest (5.10.2)
     multipart-post (2.0.0)

--- a/app/views/shift_commerce/static_pages/show.html.erb
+++ b/app/views/shift_commerce/static_pages/show.html.erb
@@ -3,7 +3,10 @@
         <h1><%= static_page.title %></h1>
         <div class="container" role="main">
             <div class="row">
-              <%= static_page.body_content.html_safe %>
+              <% body_content = static_page.meta_attribute(:static_content)%>
+              <% if body_content.present? %>
+                <%= body_content.html_safe %>
+              <% end %>
             </div>
         </div>
     <% end %>

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.6.16'
+  VERSION = '0.6.17'
 end

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.6.15'
+  VERSION = '0.6.16'
 end

--- a/spec/concerns/preview_state_management_spec.rb
+++ b/spec/concerns/preview_state_management_spec.rb
@@ -7,7 +7,7 @@ class PreviewStateManagementController < ActionController::Base
 
   def index
     page = FlexCommerce::StaticPage.includes([]).find(1).first
-    render html: page.body_content
+    render html: page.meta_attribute(:static_content)
   end
 end
 

--- a/spec/mocks/preview_state_management_mocks.rb
+++ b/spec/mocks/preview_state_management_mocks.rb
@@ -8,7 +8,13 @@ module Mocks
           self: "/testaccount/v1/static_pages/1.json_api"
         },
         attributes: {
-          body_content: "Published",
+          "meta_attributes": {
+            "static_content": {
+              "value": "Published",
+              "data_type": "textarea"
+            }
+          },
+          body_content: "",
           published: true
         }
       },
@@ -25,7 +31,13 @@ module Mocks
           self: "/testaccount/v1/static_pages/1.json_api"
         },
         attributes: {
-          body_content: "Preview",
+          "meta_attributes": {
+            "static_content": {
+              "value": "Preview",
+              "data_type": "textarea"
+            }
+          },
+          body_content: "",
           published: true
         }
       },

--- a/spec/mocks/static_page_mocks.rb
+++ b/spec/mocks/static_page_mocks.rb
@@ -10,7 +10,7 @@ module Mocks
         attributes: {
           meta_attributes: {
             static_content: {
-              value: "<p> Body content </p>",
+              value: "Test",
               data_type: "textarea"
             }
           },
@@ -20,7 +20,7 @@ module Mocks
           title: "Static Page",
           slug: "static-page",
           reference: "static-page",
-          body_content: "Test",
+          body_content: "",
           published: true,
           canonical_path: "/static_pages/1",
         },

--- a/spec/mocks/static_page_mocks.rb
+++ b/spec/mocks/static_page_mocks.rb
@@ -8,7 +8,12 @@ module Mocks
           self: "/testaccount/v1/static_pages/1.json_api"
         },
         attributes: {
-          meta_attributes: {},
+          meta_attributes: {
+            static_content: {
+              value: "<p> Body content </p>",
+              data_type: "textarea"
+            }
+          },
           template_attributes: {},
           updated_at: Time.now,
           created_at: Time.now,


### PR DESCRIPTION
The field, "body_content" on static_page resource has been deprecated. 

Proposed alternative to this is: A meta attribute "static_content" 

This PR will update the gem reflecting the same.