### PR TITLE
Bug/Update the cache-control header to include public directive

### DIFF
--- a/app/controllers/concerns/shift_commerce/http_caching.rb
+++ b/app/controllers/concerns/shift_commerce/http_caching.rb
@@ -43,7 +43,7 @@ module ShiftCommerce
       if surrogate_keys.present?
         response.headers['Surrogate-Key'] = surrogate_keys.split(' ').reject { |k| k.include?('menu_item') }.join(' ')
         response.headers['Surrogate-Control'] = 'max-age=3600,stale-if-error=86400,stale-while-revalidate=86400'
-        response.headers['Cache-Control'] = 'max-age=0, must-revalidate'
+        response.headers['Cache-Control'] = 'public, max-age=0, must-revalidate'
       end
     end
 

--- a/lib/shift_commerce/version.rb
+++ b/lib/shift_commerce/version.rb
@@ -1,3 +1,3 @@
 module ShiftCommerce
-  VERSION = '0.6.18'
+  VERSION = '0.6.19'
 end

--- a/spec/concerns/http_caching_spec.rb
+++ b/spec/concerns/http_caching_spec.rb
@@ -65,7 +65,7 @@ describe ShiftCommerce::HttpCaching, type: :controller do
 
       get :index
 
-      expect(response.header['Cache-Control']).to eq('max-age=0, must-revalidate')
+      expect(response.header['Cache-Control']).to eq('public, max-age=0, must-revalidate')
       expect(response.header['Surrogate-Key']).to eq('foo bar')
       expect(response.header['Surrogate-Control']).to include('max-age=3600,stale-if-error=86400,stale-while-revalidate=86400')
     end
@@ -90,7 +90,7 @@ describe ShiftCommerce::HttpCaching, type: :controller do
 
       expect(response.header['Vary']).to eq('Cookie')
       expect(response.header['Surrogate-Key']).to eq('foo bar')
-      expect(response.header['Cache-Control']).to eq('max-age=0, must-revalidate')
+      expect(response.header['Cache-Control']).to eq('public, max-age=0, must-revalidate')
       expect(response.header['Surrogate-Control']).to include('max-age=3600,stale-if-error=86400,stale-while-revalidate=86400')
     end
   end


### PR DESCRIPTION
With rails latest upgrade(5.2),  cache-control header is having private as its default parameter if you don't specify.

And also when we have surrogate keys set, it means we want it to be cached by Fastly, which requires the header set to public. This PR addresses the issue
